### PR TITLE
some build process cleanups

### DIFF
--- a/src/Mkvtree/Filegoals.mf
+++ b/src/Mkvtree/Filegoals.mf
@@ -30,16 +30,16 @@ cleanbuild:
 	rm -f ${COMPILEDIR}*.[ox]
 
 ${COMPILEDIR}%.o:%.c
-	${CC} ${CFLAGS} -c $< -o $@ -MT $@ -MMD -MP -MF $(@:.o=.d)
+	${CC} ${CFLAGS} ${CPPFLAGS} -c $< -o $@ -MT $@ -MMD -MP -MF $(@:.o=.d)
 
 ${COMPILEDIR}%.dbg.o:%.c
-	${CC} ${CFLAGS} -DDEBUG -c $< -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -DDEBUG -c $< -o $@
 
 %.so:%.c
-	${CC} ${CFLAGS} ${SHARED} $< -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} ${SHARED} $< -o $@
 
 %.prepro:%.c
-	${CC} -E -g3 ${CFLAGS} -DDEBUG -c $< -o $@
+	${CC} -E -g3 ${CFLAGS} ${CPPFLAGS} -DDEBUG -c $< -o $@
 	indent $@
 
 %.pr:%.c

--- a/src/Mkvtree/Makefile
+++ b/src/Mkvtree/Makefile
@@ -182,10 +182,10 @@ ${EXECDIR}mkdna6idx.dbg.x:${COMPILEDIR}mkdna6idx.dbg.o ${LIBSDBG}
 	${LD} ${LDFLAGS} ${COMPILEDIR}mkdna6idx.dbg.o ${LIBSDBG} ${LDLIBS} -o $@
 
 ${COMPILEDIR}besespecial.o:besespecial.c
-	${CC} ${CFLAGS} -DSPECIAL -c besespecial.c -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -DSPECIAL -c besespecial.c -o $@
 
 ${COMPILEDIR}besespecial.dbg.o:besespecial.c
-	${CC} ${CFLAGS} -DSPECIAL -DDEBUG -c besespecial.c -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -DSPECIAL -DDEBUG -c besespecial.c -o $@
 
 besespecial.splint:besespecial.c
 	splint ${SPLINTFLAGS} -DSPECIAL -DDEBUG besespecial.c
@@ -223,6 +223,6 @@ cleanpp:
 	cleanpp.sh
 
 cflagsstring:
-	@echo "${CFLAGS}"
+	@echo "${CFLAGS} ${CPPFLAGS}"
 
 -include $(wildcard ${COMPILEDIR}/*.d)

--- a/src/Vmatch/Filegoals.mf
+++ b/src/Vmatch/Filegoals.mf
@@ -58,16 +58,16 @@ cleanbuild:
 	rm -f ${COMPILEDIR}*.[ox]
 
 ${COMPILEDIR}%.o:%.c
-	${CC} ${CFLAGS} -c $< -o $@ -MT $@ -MMD -MP -MF $(@:.o=.d)
+	${CC} ${CFLAGS} ${CPPFLAGS} -c $< -o $@ -MT $@ -MMD -MP -MF $(@:.o=.d)
 
 ${COMPILEDIR}%.dbg.o:%.c
-	${CC} ${CFLAGS} -DDEBUG -c $< -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -DDEBUG -c $< -o $@
 
 %.so:%.c
-	${CC} ${CFLAGS} ${SHARED} $< -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} ${SHARED} $< -o $@
 
 %.prepro:%.c
-	${CC} -E -g3 ${CFLAGS} -DDEBUG -c $< -o $@
+	${CC} -E -g3 ${CFLAGS} ${CPPFLAGS} -DDEBUG -c $< -o $@
 	indent $@
 
 %.pr:%.c

--- a/src/Vmatch/Makefile
+++ b/src/Vmatch/Makefile
@@ -222,10 +222,10 @@ ${LIBVMATCHDBG}:${LIBVMATCHDBGOBJ}
 	$(RANLIB) $@
 
 vmotif-demo.o:vmotif-demo.c
-	${CC} ${CFLAGS} -fPIC -c $< -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -fPIC -c $< -o $@
 
 cpridxps-demo.o:cpridxps-demo.c
-	${CC} ${CFLAGS} -fPIC -c $< -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -fPIC -c $< -o $@
 
 vmotif-demo.so:vmotif-demo.o ${LIBKURTZ}
 	${CC} ${SHARED} $< ${LIBKURTZ} -o $@
@@ -282,6 +282,6 @@ mkincludes:
 -include Filegoals.mf
 
 cflagsstring:
-	@echo "${CFLAGS} -DALPHABETSIZE=4"
+	@echo "${CFLAGS} ${CPPFLAGS} -DALPHABETSIZE=4"
 
 -include $(wildcard ${COMPILEDIR}/*.d)

--- a/src/Vmatch/SELECT/cgvizout.c
+++ b/src/Vmatch/SELECT/cgvizout.c
@@ -99,7 +99,7 @@ static ArrayMatchdata *multmatches;
 static ArrayConnectdata *edges;
 
 /*Sorting and grouping of matches. Returns number of generated groups*/
-static Uint multmatchesCountingSort ()
+static Uint multmatchesCountingSort (void)
 {
   Uint maxmatchlen = 0,
        nof_matches,

--- a/src/Vmatch/SELECT/makefile
+++ b/src/Vmatch/SELECT/makefile
@@ -1,11 +1,11 @@
 # makefile to compile shared objects using the gnu C compiler
 # Stefan Kurtz, October 2000
 
-CC=gcc
+#CC=gcc
 
 # in 64-bit mode add -m64
 
-CFLAGS=-Wall -Werror -O3 -g
+CFLAGS+=-Wall -Werror -O3 -g
 
 ifneq ($(SYSTEM),Windows)
 CFLAGS+=-fPIC
@@ -43,15 +43,15 @@ all:selsplicesite.${SHAREDSUFFIX}\
 # on most platforms the shared objects have a suffix .so
 
 %.so:%.c Shareddef
-	${CC} ${CFLAGS} ${SHARED} $< -o $@
+	${CC} ${CFLAGS} ${SHARED} $< -o $@ ${LDFLAGS}
 
 mergematches-dbg.so:mergematches.c Shareddef
-	${CC} ${CFLAGS} -DDEBUG ${SHARED} $< -o $@
+	${CC} ${CFLAGS} -DDEBUG ${SHARED} $< -o $@ ${LDFLAGS}
 
 # on HP-UX the shared objects have a suffix .sl
 
 %.sl:%.c Shareddef
-	@${CC} ${CFLAGS} ${SHARED} $< -o $@
+	@${CC} ${CFLAGS} ${SHARED} $< -o $@ ${LDFLAGS}
 
 # the following goal generates the output of the C-preprocessor
 # applied to the given C-file.

--- a/src/Vmatch/SELECT/makefile
+++ b/src/Vmatch/SELECT/makefile
@@ -43,21 +43,21 @@ all:selsplicesite.${SHAREDSUFFIX}\
 # on most platforms the shared objects have a suffix .so
 
 %.so:%.c Shareddef
-	${CC} ${CFLAGS} ${SHARED} $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} ${CPPFLAGS} ${SHARED} $< -o $@ ${LDFLAGS}
 
 mergematches-dbg.so:mergematches.c Shareddef
-	${CC} ${CFLAGS} -DDEBUG ${SHARED} $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} ${CPPFLAGS} -DDEBUG ${SHARED} $< -o $@ ${LDFLAGS}
 
 # on HP-UX the shared objects have a suffix .sl
 
 %.sl:%.c Shareddef
-	@${CC} ${CFLAGS} ${SHARED} $< -o $@ ${LDFLAGS}
+	@${CC} ${CFLAGS} ${CPPFLAGS} ${SHARED} $< -o $@ ${LDFLAGS}
 
 # the following goal generates the output of the C-preprocessor
 # applied to the given C-file.
 
 %.prepro:%.c Shareddef
-	@${CC} -E -g3 ${CFLAGS} -c $< -o $@
+	@${CC} -E -g3 ${CFLAGS} ${CPPFLAGS} -c $< -o $@
 
 %.splint:%.c Shareddef
 	splint ${SPLINTFLAGS} -DDEBUG -DALPHABETSIZE=4 $<

--- a/src/Vmatch/SELECT/mstat.c
+++ b/src/Vmatch/SELECT/mstat.c
@@ -87,20 +87,20 @@ static Sint sortMstatvalue(Mstatvalue *p,Mstatvalue *q)
   and \(iend\). The following function reports such section.
 */
 
-static void showsection(ArrayMstatvalue *mstat,Uint istart,Uint iend)
+static void showsection(ArrayMstatvalue *mmstat,Uint istart,Uint iend)
 {
   Uint i;
   Mstatvalue *mstatptr;
 
-  printf("%lu:\n",(Showuint) mstat->spaceMstatvalue[istart].seqnum1);
+  printf("%lu:\n",(Showuint) mmstat->spaceMstatvalue[istart].seqnum1);
   for(i=istart; i<=iend; i++)
   {
-    mstatptr = mstat->spaceMstatvalue + i;
-    if(mstatptr->seqnum1 != mstat->spaceMstatvalue[istart].seqnum1)
+    mstatptr = mmstat->spaceMstatvalue + i;
+    if(mstatptr->seqnum1 != mmstat->spaceMstatvalue[istart].seqnum1)
     {
       fprintf(stderr,"seqnum1 =%lu != %lu\n",
               (Showuint) mstatptr->seqnum1,
-              (Showuint) mstat->spaceMstatvalue[istart].seqnum1);
+              (Showuint) mmstat->spaceMstatvalue[istart].seqnum1);
       exit(EXIT_FAILURE);
     }
     printf("     %lu %lu %lu %lu\n",
@@ -117,27 +117,27 @@ static void showsection(ArrayMstatvalue *mstat,Uint istart,Uint iend)
   function \texttt{showsection} is applied.
 */
 
-static void splitMstatvalues(ArrayMstatvalue *mstat)
+static void splitMstatvalues(ArrayMstatvalue *mmstat)
 {
   Uint i, lastseqnum, istart;
 
-  if(mstat->nextfreeMstatvalue == 0)
+  if(mmstat->nextfreeMstatvalue == 0)
   {
     fprintf(stderr,"no matches available\n");
     exit(EXIT_FAILURE);
   }
-  lastseqnum = mstat->spaceMstatvalue[0].seqnum1;
+  lastseqnum = mmstat->spaceMstatvalue[0].seqnum1;
   istart = 0;
-  for(i=1; i<mstat->nextfreeMstatvalue; i++)
+  for(i=1; i<mmstat->nextfreeMstatvalue; i++)
   {
-    if(lastseqnum < mstat->spaceMstatvalue[i].seqnum1)
+    if(lastseqnum < mmstat->spaceMstatvalue[i].seqnum1)
     {
-      showsection(mstat,istart,i-1);
-      lastseqnum = mstat->spaceMstatvalue[i].seqnum1;
+      showsection(mmstat,istart,i-1);
+      lastseqnum = mmstat->spaceMstatvalue[i].seqnum1;
       istart = i;
     }
   }
-  showsection(mstat,istart,i-1);
+  showsection(mmstat,istart,i-1);
 }
 
 /*

--- a/src/Vmengine/Makefile
+++ b/src/Vmengine/Makefile
@@ -43,7 +43,7 @@ clean:splintclean
 	rm -f *.[oa] *.dbg.o *.inc *.aux *.dvi *.log
 
 cflagsstring:
-	@echo "${CFLAGS}"
+	@echo "${CFLAGS} ${CPPFLAGS}"
 
 libtest:${LIBVMENGINE} ${LIBVMENGINEDBG}
 	${MAKE} -C libtest
@@ -52,16 +52,16 @@ vmengineexport.h:${VMENGINEKERN}
 	cat ${VMENGINEKERN} | skproto > $@
 
 ${COMPILEDIR}vmatfind-dyn.o:vmatfind.c ../include/virtualdef.h
-	${CC} ${CFLAGS} -DDYNAMICALPHABET -c vmatfind.c -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -DDYNAMICALPHABET -c vmatfind.c -o $@
 
 ${COMPILEDIR}vmatfind-strm.o:vmatfind.c ../include/esastream.h
-	${CC} ${CFLAGS} -DDYNAMICALPHABET -DESASTREAMACCESS -c vmatfind.c -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -DDYNAMICALPHABET -DESASTREAMACCESS -c vmatfind.c -o $@
 
 ${COMPILEDIR}vmatfind-dyn.dbg.o:vmatfind.c ../include/virtualdef.h
-	${CC} ${CFLAGS} -DDEBUG -DDYNAMICALPHABET -c vmatfind.c -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -DDEBUG -DDYNAMICALPHABET -c vmatfind.c -o $@
 
 ${COMPILEDIR}vmatfind-strm.dbg.o:vmatfind.c ../include/esastream.h
-	${CC} ${CFLAGS} -DDEBUG -DDYNAMICALPHABET -DESASTREAMACCESS -c vmatfind.c -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -DDEBUG -DDYNAMICALPHABET -DESASTREAMACCESS -c vmatfind.c -o $@
 
 vmatfind4.splint:vmatfind.c
 	splint ${SPLINTFLAGS} -DDEBUG -DALPHABETSIZE=4 vmatfind.c

--- a/src/bin/mkfilegoals.pl
+++ b/src/bin/mkfilegoals.pl
@@ -225,7 +225,7 @@ sub genericgoal
   }
   if($kind eq 'o')
   {
-    printf("\t\${CC} \${CFLAGS} -c \$< -o \$@ -MT \$@ -MMD -MP -MF \$(\@:.o=.d)\n\n");
+    printf("\t\${CC} \${CFLAGS} ${CPPFLAGS} -c \$< -o \$@ -MT \$@ -MMD -MP -MF \$(\@:.o=.d)\n\n");
   } elsif($kind eq 'splint')
   {
     printf("\tsplint \${SPLINTFLAGS} \$<\n");
@@ -235,20 +235,20 @@ sub genericgoal
     printf("\tskproto \$< > \$@\n\n");
   } elsif($kind eq 'prepro')
   {
-    printf("\t\${CC} -E -g3 \${CFLAGS} -DDEBUG -c \$< -o \$@\n");
+    printf("\t\${CC} -E -g3 \${CFLAGS} ${CPPFLAGS} -DDEBUG -c \$< -o \$@\n");
     printf("\tindent \$@\n\n");
   } elsif($kind eq 'dbg4')
   {
-    printf("\t\${CC} \${CFLAGS} -DDEBUG -DSYMBOLBYTES=4 -c \$< -o \$@\n\n");
+    printf("\t\${CC} \${CFLAGS} ${CPPFLAGS} -DDEBUG -DSYMBOLBYTES=4 -c \$< -o \$@\n\n");
   } elsif($kind eq '4')
   {
-    printf("\t\${CC} \${CFLAGS} -DSYMBOLBYTES=4 -c \$< -o \$@\n\n");
+    printf("\t\${CC} \${CFLAGS} ${CPPFLAGS} -DSYMBOLBYTES=4 -c \$< -o \$@\n\n");
   } elsif($kind eq 'dbg')
   {
-    printf("\t\${CC} \${CFLAGS} -DDEBUG -c \$< -o \$@\n\n");
+    printf("\t\${CC} \${CFLAGS} ${CPPFLAGS} -DDEBUG -c \$< -o \$@\n\n");
   } elsif($kind eq 'so')
   {
-    printf("\t\${CC} \${CFLAGS} \${SHARED} \$< -o \$@\n\n");
+    printf("\t\${CC} \${CFLAGS} ${CPPFLAGS} \${SHARED} \$< -o \$@\n\n");
   } else
   {
     printf("illegal kind value \"%s\"\n",$kind);

--- a/src/bin/mklink.sh
+++ b/src/bin/mklink.sh
@@ -31,7 +31,7 @@ ENDOFMKFILE
 cmd="make -f ${TMPFILE}"
 CFLAGS=`${cmd}`
 
-cmd="vmrelease.sh ${CFLAGS}"
+cmd="vmrelease.sh ${CFLAGS} ${CPPFLAGS}"
 ${cmd} > ${WORKVSTREESRC}/include/vmrelease.h
 
 rm -f ${TMPFILE}

--- a/src/doc/Fpiccompile
+++ b/src/doc/Fpiccompile
@@ -2,10 +2,10 @@ This example shows how to compile a shared object from more than
 one C-file:
 
 mycode.o:
-        gcc ${CFLAGS} -fPIC -c mycode.c
+        gcc ${CFLAGS} ${CPPFLAGS} -fPIC -c mycode.c
 
 selstartend.o:
-        gcc ${CFLAGS} -fPIC -c selstartend.c
+        gcc ${CFLAGS} ${CPPFLAGS} -fPIC -c selstartend.c
 
 selstartend.so:selstartend.o mycode.o
         ld -G -o selstartend.so selstartend.o mycode.o

--- a/src/kurtz-basic/Filegoals.mf
+++ b/src/kurtz-basic/Filegoals.mf
@@ -2,13 +2,13 @@ cleanbuild:
 	rm -f ${COMPILEDIR}*.[ox]
 
 ${COMPILEDIR}%.o:%.c
-	${CC} ${CFLAGS} -c $< -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -c $< -o $@
 
 ${COMPILEDIR}%.dbg.o:%.c
-	${CC} ${CFLAGS} -DDEBUG -c $< -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -DDEBUG -c $< -o $@
 
 %.prepro:%.c
-	${CC} -E -g3 ${CFLAGS} -DDEBUG -c $< -o $@
+	${CC} -E -g3 ${CFLAGS} ${CPPFLAGS} -DDEBUG -c $< -o $@
 	indent $@
 
 %.splint:%.c

--- a/src/kurtz-basic/Makefile
+++ b/src/kurtz-basic/Makefile
@@ -28,17 +28,17 @@ $(LIBKURTZBASICDBG):$(LIBDEBUGOBJECTS)
 	$(RANLIB) $@
 
 release:
-	vmrelease.sh VMATCH ${CFLAGS} > ../include/vmrelease.h
+	vmrelease.sh VMATCH ${CFLAGS} ${CPPFLAGS} > ../include/vmrelease.h
 
 chain2dim2.o:chain2dim.c
-	${CC} ${CFLAGS} -DREVERSEDIM -c $< -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -DREVERSEDIM -c $< -o $@
 
 .PHONY:clean
 clean:splintclean
 	rm -f *.[oa] *.dbg.o *.inc *.aux *.dvi *.log
 
 cflagsstring:
-	@echo "${CFLAGS}"
+	@echo "${CFLAGS} ${CPPFLAGS}"
 
 .PHONY:prototypes
 prototypes:${PROTOTYPES}

--- a/src/kurtz/Filegoals.mf
+++ b/src/kurtz/Filegoals.mf
@@ -2,13 +2,13 @@ cleanbuild:
 	rm -f ${COMPILEDIR}*.[ox]
 
 ${COMPILEDIR}%.o:%.c
-	${CC} ${CFLAGS} -c $< -o $@ -MT $@ -MMD -MP -MF $(@:.o=.d)
+	${CC} ${CFLAGS} ${CPPFLAGS} -c $< -o $@ -MT $@ -MMD -MP -MF $(@:.o=.d)
 
 ${COMPILEDIR}%.dbg.o:%.c
-	${CC} ${CFLAGS} -DDEBUG -c $< -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -DDEBUG -c $< -o $@
 
 %.prepro:%.c
-	${CC} -E -g3 ${CFLAGS} -DDEBUG -c $< -o $@
+	${CC} -E -g3 ${CFLAGS} ${CPPFLAGS} -DDEBUG -c $< -o $@
 	indent $@
 
 %.splint:%.c

--- a/src/kurtz/Makefile
+++ b/src/kurtz/Makefile
@@ -25,14 +25,14 @@ $(LIBKURTZDBG):$(LIBDEBUGOBJECTS)
 	$(RANLIB) $@
 
 release:
-	vmrelease.sh VMATCH ${CFLAGS} > ../include/vmrelease.h
+	vmrelease.sh VMATCH ${CFLAGS} ${CPPFLAGS} > ../include/vmrelease.h
 
 .PHONY:clean
 clean:splintclean
 	rm -f *.[oa] *.dbg.o *.inc *.aux *.dvi *.log
 
 cflagsstring:
-	@echo "${CFLAGS}"
+	@echo "${CFLAGS} ${CPPFLAGS}"
 
 libtest:$(LIBKURTZ) $(LIBKURTZDBG)
 	${MAKE} -C libtest

--- a/src/kurtz/libtest/Filegoals.mf
+++ b/src/kurtz/libtest/Filegoals.mf
@@ -34,16 +34,16 @@ cleanbuild:
 	rm -f ${COMPILEDIR}*.[ox]
 
 ${COMPILEDIR}%.o:%.c
-	${CC} ${CFLAGS} -c $< -o $@ -MT $@ -MMD -MP -MF $(@:.o=.d)
+	${CC} ${CFLAGS} ${CPPFLAGS} -c $< -o $@ -MT $@ -MMD -MP -MF $(@:.o=.d)
 
 ${COMPILEDIR}%.dbg.o:%.c
-	${CC} ${CFLAGS} -DDEBUG -c $< -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} -DDEBUG -c $< -o $@
 
 %.so:%.c
-	${CC} ${CFLAGS} ${SHARED} $< -o $@
+	${CC} ${CFLAGS} ${CPPFLAGS} ${SHARED} $< -o $@
 
 %.prepro:%.c
-	${CC} -E -g3 ${CFLAGS} -DDEBUG -c $< -o $@
+	${CC} -E -g3 ${CFLAGS} ${CPPFLAGS} -DDEBUG -c $< -o $@
 	indent $@
 
 %.pr:%.c

--- a/src/kurtz/libtest/Makefile
+++ b/src/kurtz/libtest/Makefile
@@ -50,7 +50,7 @@ strmfna.x:strmfna.o ${LIBS}
 	${LD} ${LDFLAGS} strmfna.o ${LIBS} ${LDLIBS} -o $@
 
 readdb.o:readdb.c
-	${CC} -c ${CFLAGS} readdb.c
+	${CC} -c ${CFLAGS} ${CPPFLAGS} readdb.c
 
 suffixprefix.x:suffixprefix.o
 	${LD} ${LDFLAGS} suffixprefix.o ${LIBSDBG} ${LDLIBS} -o $@
@@ -151,6 +151,6 @@ clean:splintclean
 	cleanpp.sh
 
 cflagsstring:
-	@echo "${CFLAGS}"
+	@echo "${CFLAGS} ${CPPFLAGS}"
 
 -include $(wildcard *.d)


### PR DESCRIPTION
This PR introduces two changes:

- Compiler flags such as `CPPFLAGS`, `CC`  etc. are passed on to the compiler calls instead of being overridden
- Build failures due to new static compiler checks on newer compiler versions are addressed