### PR TITLE
remove licensemanager remnants

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -48,10 +48,10 @@ INSTALLLIST=Mkvtree/mkvtree.x\
 
 all:
 	${MAKE} -C kurtz-basic
-	${MAKE} -C kurtz licensemanager=${licensemanager}
-	${MAKE} -C Mkvtree licensemanager=${licensemanager}
+	${MAKE} -C kurtz
+	${MAKE} -C Mkvtree
 	${MAKE} -C Vmengine
-	${MAKE} -C Vmatch licensemanager=${licensemanager}
+	${MAKE} -C Vmatch
 
 release:
 	git tag "v`cat VERSION`"
@@ -65,8 +65,8 @@ libs:
 
 vmatch:libs
 	${MAKE} -C kurtz/libtest
-	${MAKE} -C Mkvtree licensemanager=${licensemanager}
-	${MAKE} -C Vmatch licensemanager=${licensemanager}
+	${MAKE} -C Mkvtree
+	${MAKE} -C Vmatch
 
 cleanup:
 	find . -name '*.[oa]' | xargs rm -f

--- a/src/Mkvtree/Makefile
+++ b/src/Mkvtree/Makefile
@@ -9,17 +9,8 @@ LDLIBS=${DEFINELDLIBS}
 COMPILEDIR=${COMPILEDIRPREFIX}/Mkvtree/
 #EXECDIR=${EXECDIRPREFIX}/Mkvtree/
 
-ifneq ($(licensemanager),no)
-  CFLAGS += -I../../../licensemanager/src \
-            -I../../../genometools/src
-  LDLIBS = ${CURDIR}/../../../licensemanager/lib/$(BIT)/liblicensemanager.a \
-           ${CURDIR}/../../../genometools/lib/libgenometools.a \
-           ${DEFINELDLIBS}
-else
-  CFLAGS += -DNOLICENSEMANAGER
-  LDLIBS = ${CURDIR}/../../../genometools/lib/libgenometools.a \
-           ${DEFINELDLIBS}
-endif
+LDLIBS = ${CURDIR}/../../../genometools/lib/libgenometools.a \
+         ${DEFINELDLIBS}
 
 MKVTREEOBJ=${COMPILEDIR}mkvtree.o\
            ${COMPILEDIR}mkvprocess.o\

--- a/src/Mkvtree/mkdna6idx.c
+++ b/src/Mkvtree/mkdna6idx.c
@@ -30,10 +30,6 @@
 #include "mkvprocess.pr"
 #include "mkvtree.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 static void showonstdout(char *s)
 {
   printf("%s\n",s);
@@ -116,11 +112,6 @@ MAINFUNCTION
   Sint ret;
   Showverbose showverbose;
   Uint transnum;
-#ifndef NOLICENSEMANAGER
-  LmLicense *license;
-  if (!(license = lm_license_new_vmatch(argv[0])))
-    return EXIT_FAILURE;
-#endif
 
   if(extractoption("-v",argv,argc) > 0)
   {
@@ -214,8 +205,5 @@ MAINFUNCTION
 #endif
   mmcheckspaceleak();
   checkfilehandles();
-#ifndef NOLICENSEMANAGER
-  lm_license_delete(license);
-#endif
   return EXIT_SUCCESS;
 }

--- a/src/Mkvtree/mkvfile.c
+++ b/src/Mkvtree/mkvfile.c
@@ -13,10 +13,6 @@
 #include "readvirt.pr"
 #include "filehandle.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 static void showonstdout(char *s)
 {
   printf("%s\n",s);
@@ -45,18 +41,9 @@ MAINFUNCTION
 #ifndef NOSPACEBOOKKEEPING
   Sint i;
 #endif
-#ifndef NOLICENSEMANAGER
-  LmLicense *license;
-  if (!(license = lm_license_new_vmatch(argv[0])))
-    return EXIT_FAILURE;
-#endif
 
   DEBUGLEVELSET;
-#ifndef NOLICENSEMANAGER
-  CALLSHOWPROGRAMVERSIONWITHLICENSE("mkvtree", license);
-#else
   CALLSHOWPROGRAMVERSION("mkvtree");
-#endif
   makeemptyvirtualtree(&virtualtree);
   ret = callmkvtree(argc,argv,True,&virtualtree,True,showonstdout);
   if(ret == (Sint) 1)
@@ -88,8 +75,5 @@ MAINFUNCTION
   mmcheckspaceleak();
 #endif
   checkfilehandles();
-#ifndef NOLICENSEMANAGER
-  lm_license_delete(license);
-#endif
   return EXIT_SUCCESS;
 }

--- a/src/Mkvtree/mkvtree.c
+++ b/src/Mkvtree/mkvtree.c
@@ -25,10 +25,6 @@
 #include "mkvprocess.pr"
 #include "getbasename.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 #define USAGEERRORCODE (-99)
 
 #define MAXTABOPTSPACE 256
@@ -602,10 +598,6 @@ Sint callmkvtreegeneric(BOOL useformkrcidx,
 {
   Input input;
   Sint pret;
-
-#ifndef NOLICENSEMANAGER
-  lm_license_check_j();
-#endif
 
 #ifdef DEBUG
   showargumentlist(argc,argv);

--- a/src/Mkvtree/vseqinfo.c
+++ b/src/Mkvtree/vseqinfo.c
@@ -12,18 +12,9 @@
 #include "filehandle.pr"
 #include "multiseq-adv.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 MAINFUNCTION
 {
   Virtualtree virtualtree;
-#ifndef NOLICENSEMANAGER
-  LmLicense *license;
-  if (!(license = lm_license_new_vmatch(argv[0])))
-    return EXIT_FAILURE;
-#endif
 
   VSTREECHECKARGNUM(2,"indexname");
   DEBUGLEVELSET;
@@ -45,8 +36,5 @@ MAINFUNCTION
 #endif
   mmcheckspaceleak();
   checkfilehandles();
-#ifndef NOLICENSEMANAGER
-  lm_license_delete(license);
-#endif
   return EXIT_SUCCESS;
 }

--- a/src/Mkvtree/vseqselect.c
+++ b/src/Mkvtree/vseqselect.c
@@ -25,10 +25,6 @@
 #include "safescpy.pr"
 #include "filehandle.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 #define MAXPART 0.5    // maximum of randomselnum/numofsequences resp.
                        // randomsellength/numofsequences
 
@@ -523,18 +519,9 @@ MAINFUNCTION
   Virtualtree virtualtree;
   Sint ret;
   Selectcallinfo selectcallinfo;
-#ifndef NOLICENSEMANAGER
-  LmLicense *license;
-  if (!(license = lm_license_new_vmatch(argv[0])))
-    return EXIT_FAILURE;
-#endif
 
   DEBUGLEVELSET;
-#ifndef NOLICENSEMANAGER
-  CALLSHOWPROGRAMVERSIONWITHLICENSE("vseqselect", license);
-#else
   CALLSHOWPROGRAMVERSION("vseqselect");
-#endif
   ret = parseseselect(&selectcallinfo,argv,argc);
   if(ret == (Sint) 1)
   {
@@ -624,8 +611,5 @@ MAINFUNCTION
 #endif
   mmcheckspaceleak();
   checkfilehandles();
-#ifndef NOLICENSEMANAGER
-  lm_license_delete(license);
-#endif
   return EXIT_SUCCESS;
 }

--- a/src/Mkvtree/vstree2tex.c
+++ b/src/Mkvtree/vstree2tex.c
@@ -17,10 +17,6 @@
 #include "filehandle.pr"
 #include "safescpy.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 #define BCKTABHORIZONTAL FIRSTBIT
 
 typedef struct
@@ -187,18 +183,9 @@ MAINFUNCTION
   Callinfo callinfo;
   Uint demand;
   Sint retval;
-#ifndef NOLICENSEMANAGER
-  LmLicense *license;
-  if (!(license = lm_license_new_vmatch(argv[0])))
-    return EXIT_FAILURE;
-#endif
 
   DEBUGLEVELSET;
-#ifndef NOLICENSEMANAGER
-  CALLSHOWPROGRAMVERSIONWITHLICENSE("vstree2tex", license);
-#else
   CALLSHOWPROGRAMVERSION("vstree2tex");
-#endif
   retval = parseoptions(&callinfo,argc,argv);
   if(retval == (Sint) -1)
   {
@@ -236,8 +223,5 @@ MAINFUNCTION
 #endif
   mmcheckspaceleak();
   checkfilehandles();
-#ifndef NOLICENSEMANAGER
-  lm_license_delete(license);
-#endif
   return EXIT_SUCCESS;
 }

--- a/src/Mkvtree/vsubseqselect.c
+++ b/src/Mkvtree/vsubseqselect.c
@@ -22,10 +22,6 @@
 #include "safescpy.pr"
 #include "multiseq.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 #define READPOSITIVEINT\
         READINTGENERIC(options[(Uint) optval].optname,\
                        readint,argc-1,<=,"positive")
@@ -343,19 +339,10 @@ MAINFUNCTION
   Virtualtree virtualtree;
   Sint ret;
   Selectcallinfo selectcallinfo;
-#ifndef NOLICENSEMANAGER
-  LmLicense *license;
-  if (!(license = lm_license_new_vmatch(argv[0])))
-    return EXIT_FAILURE;
-#endif
 
   DEBUGLEVELSET;
 
-#ifndef NOLICENSEMANAGER
-  CALLSHOWPROGRAMVERSIONWITHLICENSE("vsubseqselect", license);
-#else
   CALLSHOWPROGRAMVERSION("vsubseqselect");
-#endif
   ret = parseseselect(&selectcallinfo,argv,argc);
   if(ret == (Sint) 1)
   {
@@ -430,8 +417,5 @@ MAINFUNCTION
 #endif
   mmcheckspaceleak();
   checkfilehandles();
-#ifndef NOLICENSEMANAGER
-  lm_license_delete(license);
-#endif
   return EXIT_SUCCESS;
 }

--- a/src/Vmatch/Makefile
+++ b/src/Vmatch/Makefile
@@ -11,17 +11,8 @@ LDLIBS=${DEFINELDLIBS}
 COMPILEDIR=${COMPILEDIRPREFIX}/Vmatch/
 #EXECDIR=${EXECDIRPREFIX}/Vmatch/
 
-ifneq ($(licensemanager),no)
-  CFLAGS += -I../../../licensemanager/src \
-            -I../../../genometools/src
-  LDLIBS = ${CURDIR}/../../../licensemanager/lib/$(BIT)/liblicensemanager.a \
-           ${CURDIR}/../../../genometools/lib/libgenometools.a \
-           ${DEFINELDLIBS}
-else
-  CFLAGS += -DNOLICENSEMANAGER
-  LDLIBS = ${CURDIR}/../../../genometools/lib/libgenometools.a \
-           ${DEFINELDLIBS}
-endif
+LDLIBS = ${CURDIR}/../../../genometools/lib/libgenometools.a \
+         ${DEFINELDLIBS}
 
 LIBS=${LIBVMATCH}\
      ${LIBVMENGINE}\

--- a/src/Vmatch/chain2dim.mn.c
+++ b/src/Vmatch/chain2dim.mn.c
@@ -25,26 +25,13 @@
 #include "chncallparse.pr"
 #include "echomatch.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 MAINFUNCTION
 {
   Chaincallinfo chaincallinfo;
   Sint ret;
-#ifndef NOLICENSEMANAGER
-  LmLicense *license;
-  if (!(license = lm_license_new_vmatch(argv[0])))
-    return EXIT_FAILURE;
-#endif
 
   DEBUGLEVELSET;
-#ifndef NOLICENSEMANAGER
-  CALLSHOWPROGRAMVERSIONWITHLICENSE("chain2dim", license);
-#else
   CALLSHOWPROGRAMVERSION("chain2dim");
-#endif
   ret = parsechain2dim(False,&chaincallinfo, argv, argc);
   if(ret == (Sint) 1)
   {
@@ -120,8 +107,5 @@ MAINFUNCTION
 #endif
   mmcheckspaceleak();
   checkfilehandles();
-#ifndef NOLICENSEMANAGER
-  lm_license_delete(license);
-#endif
   return EXIT_SUCCESS;
 }

--- a/src/Vmatch/matchcl.mn.c
+++ b/src/Vmatch/matchcl.mn.c
@@ -15,10 +15,6 @@
 #include "parsemcl.pr"
 #include "allmclust.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 static void showonstdout(char *s)
 {
   printf("# %s\n",s);
@@ -29,18 +25,9 @@ MAINFUNCTION
   Matchinfo matchinfo;
   Matchclustercallinfo matchclustercallinfo;
   Sint retcode;
-#ifndef NOLICENSEMANAGER
-  LmLicense *license;
-  if (!(license = lm_license_new_vmatch(argv[0])))
-    return EXIT_FAILURE;
-#endif
 
   DEBUGLEVELSET;
-#ifndef NOLICENSEMANAGER
-  CALLSHOWPROGRAMVERSIONWITHLICENSE("matchcluster", license);
-#else
   CALLSHOWPROGRAMVERSION("matchcluster");
-#endif
   retcode = parsematchcluster(False,
                               &matchclustercallinfo,
                               argv,
@@ -85,8 +72,5 @@ MAINFUNCTION
 #endif
   mmcheckspaceleak();
   checkfilehandles();
-#ifndef NOLICENSEMANAGER
-  lm_license_delete(license);
-#endif
   return EXIT_SUCCESS;
 }

--- a/src/Vmatch/virtualexp.h
+++ b/src/Vmatch/virtualexp.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2000-2005 Stefan Kurtz <kurtz@zbh.uni-hamburg.de>
+  Copyright (c) 2000-2006 Stefan Kurtz <kurtz@zbh.uni-hamburg.de>
 
   Permission to use, copy, modify, and distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/Vmatch/vmatch.c
+++ b/src/Vmatch/vmatch.c
@@ -19,10 +19,6 @@
 #include "parsevm.pr"
 #include "procargs.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 #ifndef NOSPACEBOOKKEEPING
 static void printspacepeak(Showverbose showverbose,
                            Uint totallength)
@@ -65,10 +61,6 @@ Sint callvmatch(Argctype argc,
   Sint pret;
 
   assert(functionname);
-
-#ifndef NOLICENSEMANAGER
-  lm_license_check_k();
-#endif
 
 #ifdef SIXTYFOURBITS
   if(setlocalpagesize() != 0)

--- a/src/Vmatch/vmatch.mn.c
+++ b/src/Vmatch/vmatch.mn.c
@@ -19,10 +19,6 @@
 #include "readvirt.pr"
 #include "filehandle.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 static void showonstdout(char *s)
 {
   printf("# %s\n",s);
@@ -44,18 +40,9 @@ MAINFUNCTION
               dnavirtualtree;
   Sint retcode;
   BOOL vmatchshowtimespace;
-#ifndef NOLICENSEMANAGER
-  LmLicense *license;
-  if (!(license = lm_license_new_vmatch(argv[0])))
-    return EXIT_FAILURE;
-#endif
 
   DEBUGLEVELSET;
-#ifndef NOLICENSEMANAGER
-  CALLSHOWPROGRAMVERSIONWITHLICENSE("vmatch", license);
-#else
   CALLSHOWPROGRAMVERSION("vmatch");
-#endif
   retcode = checkenvvaronoff("VMATCHSHOWTIMESPACE");
   if(retcode == (Sint) -1)
   {
@@ -112,8 +99,5 @@ MAINFUNCTION
 #endif
   mmcheckspaceleak();
   checkfilehandles();
-#ifndef NOLICENSEMANAGER
-  lm_license_delete(license);
-#endif
   return EXIT_SUCCESS;
 }

--- a/src/Vmatch/vmatsel.mn.c
+++ b/src/Vmatch/vmatsel.mn.c
@@ -30,10 +30,6 @@
 #include "echomatch.pr"
 #include "explain.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 static void showonstdout(char *s)
 {
   printf("# %s\n",s);
@@ -300,18 +296,9 @@ MAINFUNCTION
   Sint pret;
   Matchinfo matchinfo;
   Matchcallinfo matchcallinfo;
-#ifndef NOLICENSEMANAGER
-  LmLicense *license;
-  if (!(license = lm_license_new_vmatch(argv[0])))
-    return EXIT_FAILURE;
-#endif
 
   DEBUGLEVELSET;
-#ifndef NOLICENSEMANAGER
-  CALLSHOWPROGRAMVERSIONWITHLICENSE("vmatchselect", license);
-#else
   CALLSHOWPROGRAMVERSION("vmatchselect");
-#endif
   pret = parsevmatchargs(False,
                          argc,
                          argv,
@@ -374,8 +361,5 @@ MAINFUNCTION
 #endif
   mmcheckspaceleak();
   checkfilehandles();
-#ifndef NOLICENSEMANAGER
-  lm_license_delete(license);
-#endif
   return EXIT_SUCCESS;
 }

--- a/src/kurtz-basic/Makefile
+++ b/src/kurtz-basic/Makefile
@@ -6,13 +6,6 @@ CFLAGS=${WITHSYSCONF} ${DEFINECFLAGS} ${DEFINECPPFLAGS}
 SPLINTFLAGS=${WITHSYSCONF} ${DEFINESPLINTFLAGS} ${DEFINECPPFLAGS}
 COMPILEDIR=${COMPILEDIRPREFIX}/kurtz-basic/
 
-ifneq ($(licensemanager),no)
-  CFLAGS += -I../../../licensemanager/src \
-            -I../../../genometools/src
-else
-  CFLAGS += -DNOLICENSEMANAGER
-endif
-
 -include Filelists.mf
 
 all:release mkdircompiledir prototypes $(LIBKURTZBASIC) $(LIBKURTZBASICDBG)

--- a/src/kurtz-basic/multiseq-adv.c
+++ b/src/kurtz-basic/multiseq-adv.c
@@ -37,10 +37,6 @@
 #include "endianess.pr"
 #include "checkgzip.pr"
 
-#ifndef NOLICENSEMANAGER
-#include "licensemanager.h"
-#endif
-
 //}
 
 /*EE 
@@ -2010,10 +2006,6 @@ Sint mapmultiseqifyoucan(Uint *indexsize,
 {
   Uint numofbytes;
   char *tmpfilename;
-
-#ifndef NOLICENSEMANAGER
-  lm_license_check_l();
-#endif
 
   if(demandTISTAB)
   {

--- a/src/kurtz/Makefile
+++ b/src/kurtz/Makefile
@@ -6,10 +6,6 @@ CFLAGS=${DEFINECFLAGS} ${DEFINECPPFLAGS}
 SPLINTFLAGS=${WITHSYSCONF} ${DEFINESPLINTFLAGS} ${DEFINECPPFLAGS}
 COMPILEDIR=${COMPILEDIRPREFIX}/kurtz/
 
-ifeq ($(licensemanager),no)
-  CFLAGS += -DNOLICENSEMANAGER
-endif
-
 -include Filelists.mf
 
 all:mkdircompiledir prototypes $(LIBKURTZ) $(LIBKURTZDBG)


### PR DESCRIPTION
Makes `make licensemanager=no` unnecesssary.

Issue #11