### PR TITLE
do not use potentially realloc'd pointer

### DIFF
--- a/src/kurtz-basic/space.c
+++ b/src/kurtz-basic/space.c
@@ -269,18 +269,18 @@ static ResourceEntry *reusespaceblock(void *ptr,
   void *tmpptr;
   ResourceEntry *reuseresource;
 
-  tmpptr = realloc(ptr,(size_t) (size*number));
-  if(tmpptr == NULL)
-  {
-    ALLOCERRORMSG("reusespaceblock",
-                  "not enough space for the space block");
-    exit(EXIT_FAILURE);
-  }
   reuseresource = findthespaceblock(ptr);
   if(reuseresource == NULL)
   {
     ALLOCERRORMSG("reusespaceblock",
                   "cannot find space block");
+    exit(EXIT_FAILURE);
+  }
+  tmpptr = realloc(ptr,(size_t) (size*number));
+  if(tmpptr == NULL)
+  {
+    ALLOCERRORMSG("reusespaceblock",
+                  "not enough space for the space block");
     exit(EXIT_FAILURE);
   }
   if(ptr != tmpptr)


### PR DESCRIPTION
The current version of Vmatch fails to build on newer Debian versions with GCC 12:
```
cc -DWITHSYSCONF -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -g -Wstrict-prototypes -O3 -Wundef -Wshadow -Wstrict-prototypes -Wcast-align -Wsign-compare -Wnested-externs -Wall -Wcast-qual -Wpointer-arith -Winline -Werror -Wno-unused-but-set-variable -Wno-cast-qual -Wno-error=maybe-uninitialized -fno-stack-protector -D_GNU_SOURCE -Wno-error=format-overflow -Wdate-time -D_FORTIFY_SOURCE=2 -I../include -DNOLICENSEMANAGER -Wdate-time -D_FORTIFY_SOURCE=2 -c space.c -o ../lib/libfiles/kurtz-basic/space.o
In function ‘findthespaceblock’,
    inlined from ‘reusespaceblock’ at space.c:279:19,
    inlined from ‘allocandusespaceviaptr’ at space.c:397:19:
space.c:222:22: error: pointer ‘ptr’ may be used after ‘realloc’ [-Werror=use-after-free]
  222 |   findblock.keyvalue = ptr;
      |   ~~~~~~~~~~~~~~~~~~~^~~~~
In function ‘reusespaceblock’,
    inlined from ‘allocandusespaceviaptr’ at space.c:397:19:
space.c:272:12: note: call to ‘realloc’ here
  272 |   tmpptr = realloc(ptr,(size_t) (size*number));
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```
It looks like the code uses `ptr` after it may be invalidated by `realloc`. This is caught by the static checker in the new compiler version and raised as a warning, and, as we're using `-Werror`, consequently as an error, breaking the build.
This PR addresses this by moving the use of `ptr` before the `realloc` call. Please review carefully (maybe even @stefan-kurtz?) since I am not the original author of this code.